### PR TITLE
Update ansible-lint rules

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,11 +1,8 @@
 skip_list:
    - '102'  # No Jinja2 in when
    - '106'  # Role name {} does not match ``^[a-z][a-z0-9_]+$`` pattern
-   - '208'  # File permissions not mentioned
-   - '301'  # Commands should not change things if nothing needs doing
    - '303'  # systemctl used in place of systemd module
-   - '306'  # Shells that use pipes should set the pipefail option 
-   - '602'  # Don't compare to empty string
    - '701'  # Role info should contain platforms
 warn_list:
-   - '502'  # All tasks should be named
+   - '301'  # Commands should not change things if nothing needs doing
+   - '602'  # Don't compare to empty string

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -229,4 +229,3 @@ enable_stf: False
 # Corresponds to CollectdEnableMcelog in THT
 # Set to true to enable mcelog
 collectd_enable_mcelog: False
-

--- a/molecule/amqp_default_interval/verify.yml
+++ b/molecule/amqp_default_interval/verify.yml
@@ -14,5 +14,6 @@
       command:
         grep "Interval" {{ collectd_conf_output_dir }}/amqp1.conf
       register: interval
+      changed_when: False
       failed_when:
         - "{{ ( interval.stdout | length != 0 ) or ( interval.stderr_lines | length != 0 ) }}"

--- a/molecule/collectd_connection/verify.yml
+++ b/molecule/collectd_connection/verify.yml
@@ -30,6 +30,7 @@
       command:
         cat {{ collectd_conf_output_dir }}/network.conf
       register: conf
+      changed_when: True
 
     - debug:
        var: conf.stdout
@@ -38,6 +39,7 @@
       command:
         grep "<Server .*>" {{ collectd_conf_output_dir }}/network.conf
       register: output
+      changed_when: False
       failed_when: "{{ output.stdout | length == 0 }}"
 
     - debug:
@@ -68,10 +70,13 @@
       delay: 5
       register: plugins
       until: plugins.rc == 0
+      changed_when: False
       failed_when: ( plugins.stdout_lines|length == 0 ) or ( plugins.stderr | length > 0 )
 
     - name: "Make sure the metrics on collectd-server are from collectd-test"
-      shell:
+      shell: |
+        set -o pipefail
         collectdctl -s /var/run/collectd-socket listval | grep ^collectd-test/ | wc -l
       register: test_plugins
+      changed_when: False
       failed_when: "{{ plugins.stdout_lines | length != test_plugins.stdout | int }}"

--- a/molecule/collectd_connection/verify.yml
+++ b/molecule/collectd_connection/verify.yml
@@ -30,7 +30,7 @@
       command:
         cat {{ collectd_conf_output_dir }}/network.conf
       register: conf
-      changed_when: True
+      changed_when: False
 
     - debug:
        var: conf.stdout

--- a/molecule/common/verify.yml
+++ b/molecule/common/verify.yml
@@ -20,6 +20,7 @@
       command: |
         ls {{ collectd_conf_output_dir  }}
       register: plugins
+      changed_when: False
       failed_when: >
         ( plugins.stdout_lines | length < 1 ) or
         ( 'logfile.conf' not in plugins.stdout_lines )
@@ -48,9 +49,11 @@
             /usr/sbin/collectd -C /etc/collectd.conf
 
     - name: "Get logfile path"
-      shell:
+      shell: |
+        set -o pipefail
         grep "File" {{ collectd_conf_output_dir }}/logfile.conf | awk '{ print $NF }'
       register: logfile_path
+      changed_when: False
 
     - name: "Make sure there is a directory for the logfile to live in since collectd doesn't seem to create this by default"
       stat:

--- a/tasks/configure_collectd.yml
+++ b/tasks/configure_collectd.yml
@@ -4,5 +4,8 @@
     name: collectd_config
 
 - name: "Update include dir for configs"
-  command: |
-    sed -i 's#{{ collectd_conf_output_dir }}#/etc/collectd.d/#g' {{ collectd_conf_output_dir }}/../collectd.conf
+  lineinfile:
+    path: "{{ collectd_conf_output_dir }}/../collectd.conf"
+    regexp: "^(.*){{ collectd_conf_output_dir }}(.*)$"
+    line: '\1/etc/collectd.d/\2'
+    backrefs: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -105,7 +105,7 @@
         msg: "Collectd plugin list has been updated, the following plugins will be enabled: {{ collectd_plugins }}"
 
     - name: "Create the collectd network config."
-      when: collectd_server != ''
+      when: collectd_server | length != 0
       block:
         - name: "Populate the initial config for network server."
           set_fact:


### PR DESCRIPTION
Clean up some lingering ansible-lint exceptions

Some are straighforward to resolve, but others make less sense to change, so the rules are left as warnings rather than to be skipped entirely.