### PR TITLE
[molecule][collectd_connection] Change retry criteria for checking ne…

### DIFF
--- a/molecule/collectd_connection/verify.yml
+++ b/molecule/collectd_connection/verify.yml
@@ -67,8 +67,8 @@
       retries: 3
       delay: 5
       register: plugins
-      until: plugins.rc == 0
-      failed_when: ( plugins.stdout_lines|length == 0 ) or ( plugins.stderr | length > 0 )
+      until: plugins.stdout_lines | length > 0
+      failed_when: ( plugins.stderr | length > 0 ) or ( plugins.rc != 0 )
 
     - name: "Make sure the metrics on collectd-server are from collectd-test"
       shell:


### PR DESCRIPTION
The retry module is used for checking whether the network
plugin is set up correctly in order to compensate for
delays in generating, sending and receiving metrics.

The task parameters were updated so that the failure happend
with a non-zero rc, and the task continues to retry until
there is a list of metrics (i.e. stdout_lines|len != 0), or
the retry counter runs out.
Previously, the retry counter wouldn't get past the first
iteration due to incorrect failure criteria.