### PR TITLE
[GHA] Update molecule jobs to run one scenario per job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
         uses: gofrolist/molecule-action@v2
         with:
           molecule_command: test
-          molecule_args: --all
+          molecule_args: -s ${{ matrix.scenario }}
           molecule_working_dir: ${{ github.repository }}
 
   lint:


### PR DESCRIPTION
Replace the --all arg with -s ${{ matrix.scenario }}, which was the
intended behaviour